### PR TITLE
fix(ci/cd): correct the typo that caused the update to fail

### DIFF
--- a/.github/workflows/update-flake-packages.yml
+++ b/.github/workflows/update-flake-packages.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         token: ${{ secrets.WORKFLOW_PR_TOKEN }}
         # Ensure all *-firmwares are on the blacklist.
-        blacklist: default,pico-fido-firmwares,pico-openpgp-firmwares,pico-fido2-fimrwares
+        blacklist: default,pico-fido-firmwares,pico-openpgp-firmwares,pico-fido2-firmwares
         pr-body: |
           Automated changes by the [nix-update-actions](https://github.com/gepbird/nix-update-action) GitHub Action.
         pr-labels: "automated"


### PR DESCRIPTION
I noticed that @lockedmutex  raised an issue regarding a workflow failure in the Matrix group. If you're referring to this repository, this commit should fix it.